### PR TITLE
Adjusted job resource getState() to match specification

### DIFF
--- a/src/Model/Resource/Job.php
+++ b/src/Model/Resource/Job.php
@@ -49,7 +49,7 @@ class Job extends AbstractResource
         return $this->id;
     }
 
-    public function getState(): int
+    public function getState(): string
     {
         return $this->state;
     }


### PR DESCRIPTION
Adjusted the getState() function of job resources to match the actual specification (https://test-api.psw-group.de/v1) because it causes an PHP TypeError otherwise.